### PR TITLE
remove redirect after uploading file

### DIFF
--- a/bp-attachment-xprofile-field-type.php
+++ b/bp-attachment-xprofile-field-type.php
@@ -55,11 +55,10 @@ function bpaxft_handle_uploaded_file() {
 				);
 
 				// TODO If xprofile_set_field_data() failed, we should handle that here.
-				// TODO Can this be more portable? Without this redirect, xprofile_set_field_data() doesn't take.
-				// See https://codex.buddypress.org/plugindev/bp_attachment.
-				bp_core_redirect( $_SERVER['REQUEST_URI'] );
 			}
-		} elseif ( isset( $_POST['field_ids'] ) && isset( $_POST['bpaxft_field_id'] ) ) {
+		}
+		
+		if ( isset( $_POST['field_ids'] ) && isset( $_POST['bpaxft_field_id'] ) ) {
 			$field_id = $_POST['bpaxft_field_id'];
 
 			// In case visibility changed, handle that first since we're bypassing xprofile_screen_edit_profile().
@@ -74,4 +73,4 @@ function bpaxft_handle_uploaded_file() {
 		}
 	}
 }
-add_action( 'init', 'bpaxft_handle_uploaded_file' );
+add_action( 'bp_actions', 'bpaxft_handle_uploaded_file' );


### PR DESCRIPTION
Currently, while editing a user's profile, if they upload a CV and also edit other fields, the edits to the other fields are lost. This is because in bp-attachment-xprofile-field-type.php::bpaxft_handle_uploaded_file(), if there is an uploaded file, a redirect is triggered after the upload is saved but before the rest of the submitted data can be processed.

As a comment notes, if the redirect is removed, then the upload doesn't stick. It seems as though this solution was found by consulting [this sample plugin](https://codex.buddypress.org/plugindev/bp_attachment/), which also has a redirect after processing the upload. However, there isn't anything special about the redirect. All it is doing is preventing the rest of the form from being processed.

If the field_id of the CV upload is removed from the list of field_ids to be processed by the regular bp_xprofile process, then the upload will 'stick' and the rest of the form can be processed normally. The code to do this already existed in the function, it was just conditionally called when there was no file uploaded. If it is always called, then there is no need for the redirect.

closes MESH-Research/commons#86